### PR TITLE
Store maps in a table, and add description support

### DIFF
--- a/lua/nest-modules/inspect.lua
+++ b/lua/nest-modules/inspect.lua
@@ -10,6 +10,7 @@ module.saveMapping = function(config, rhs, description)
     table.insert(
         mappings,
         vim.tbl_extend(
+            "force",
             config,
             {
                 rhs = type(rhs) == "function"

--- a/lua/nest-modules/inspect.lua
+++ b/lua/nest-modules/inspect.lua
@@ -6,7 +6,7 @@ module.getMappings = function()
     return mappings
 end
 
-module.saveMapping = function(config, rhs, description)
+module.saveMapping = function(config, rhs, name)
     table.insert(
         mappings,
         vim.tbl_extend(
@@ -16,7 +16,7 @@ module.saveMapping = function(config, rhs, description)
                 rhs = type(rhs) == "function"
                     and "<Lua function>"
                     or rhs,
-                description = description,
+                name = name,
             }
         )
     )

--- a/lua/nest-modules/inspect.lua
+++ b/lua/nest-modules/inspect.lua
@@ -1,0 +1,24 @@
+local module = {}
+
+local mappings = {}
+
+module.getMappings = function()
+    return mappings
+end
+
+module.saveMapping = function(config, rhs, description)
+    table.insert(
+        mappings,
+        vim.tbl_extend(
+            config,
+            {
+                rhs = type(rhs) == "function"
+                    and "<Lua function>"
+                    or rhs,
+                description = description,
+            }
+        )
+    )
+end
+
+return module

--- a/lua/nest.lua
+++ b/lua/nest.lua
@@ -14,6 +14,9 @@ module.defaults = {
 
 local rhsFns = {}
 
+-- Create empty table to hold mapping info for later reference
+NestMapsTable = {}
+
 module._callRhsFn = function(index)
     rhsFns[index]()
 end
@@ -110,6 +113,28 @@ module.applyKeymaps = function (config, presets)
     local rhs = type(second) == 'function'
         and functionToRhs(second, mergedPresets.options.expr)
         or second
+
+    local mapConfig = {}
+    if mergedPresets.mode ~= nil then
+        mapConfig.mode = mergedPresets.mode
+    end
+
+    if mergedPresets.buffer ~= nil then
+        mapConfig.buffer = mergedPresets.buffer
+    end
+
+    if mergedPresets.options ~= nil then
+        mapConfig.options = copy(mergedPresets.options)
+    end
+
+    mapConfig.lhs = mergedPresets.prefix
+    mapConfig.rhs = rhs
+
+    if type(config[3]) == "string" then
+        mapConfig.description = config[3]
+    end
+
+    table.insert(NestMapsTable,mapConfig)
 
     for mode in string.gmatch(mergedPresets.mode, '.') do
         local sanitizedMode = mode == '_'

--- a/lua/nest.lua
+++ b/lua/nest.lua
@@ -1,5 +1,7 @@
 local module = {}
 
+local inspect = require 'nest-modules.inspect'
+
 --- Defaults being applied to `applyKeymaps`
 -- Can be modified to change defaults applied.
 module.defaults = {
@@ -14,9 +16,6 @@ module.defaults = {
 
 local rhsFns = {}
 
--- Create empty table to hold mapping info for later reference
-NestMapsTable = {}
-
 module._callRhsFn = function(index)
     rhsFns[index]()
 end
@@ -25,16 +24,6 @@ module._getRhsExpr = function(index)
     local keys = rhsFns[index]()
 
     return vim.api.nvim_replace_termcodes(keys, true, true, true)
-end
-
-local function functionToRhs(func, expr)
-    table.insert(rhsFns, func)
-
-    local insertedIndex = #rhsFns
-
-    return expr
-        and 'v:lua.package.loaded.nest._getRhsExpr(' .. insertedIndex .. ')'
-        or '<cmd>lua package.loaded.nest._callRhsFn(' .. insertedIndex .. ')<cr>'
 end
 
 local function copy(table)
@@ -47,14 +36,14 @@ local function copy(table)
     return ret
 end
 
-local function mergeTables(left, right)
-    local ret = copy(left)
+local function functionToRhs(func, expr)
+    table.insert(rhsFns, func)
 
-    for key, value in pairs(right) do
-        ret[key] = value
-    end
+    local insertedIndex = #rhsFns
 
-    return ret
+    return expr
+        and 'v:lua.package.loaded.nest._getRhsExpr(' .. insertedIndex .. ')'
+        or '<cmd>lua package.loaded.nest._callRhsFn(' .. insertedIndex .. ')<cr>'
 end
 
 local function mergeOptions(left, right)
@@ -77,7 +66,7 @@ local function mergeOptions(left, right)
     end
 
     if right.options ~= nil then
-        ret.options = mergeTables(ret.options, right.options)
+        ret.options = vim.tbl_extend("force", ret.options, right.options)
     end
 
     return ret
@@ -114,27 +103,7 @@ module.applyKeymaps = function (config, presets)
         and functionToRhs(second, mergedPresets.options.expr)
         or second
 
-    local mapConfig = {}
-    if mergedPresets.mode ~= nil then
-        mapConfig.mode = mergedPresets.mode
-    end
-
-    if mergedPresets.buffer ~= nil then
-        mapConfig.buffer = mergedPresets.buffer
-    end
-
-    if mergedPresets.options ~= nil then
-        mapConfig.options = copy(mergedPresets.options)
-    end
-
-    mapConfig.lhs = mergedPresets.prefix
-    mapConfig.rhs = rhs
-
-    if type(config[3]) == "string" then
-        mapConfig.description = config[3]
-    end
-
-    table.insert(NestMapsTable,mapConfig)
+    inspect.saveMapping(mergedPresets, second, config.name)
 
     for mode in string.gmatch(mergedPresets.mode, '.') do
         local sanitizedMode = mode == '_'


### PR DESCRIPTION
This adds a global table `NestMapsTable` that holds all nest mappings (providing a base that future integrations can build off of), and adds very minimal support for descriptions (they can be added as a 3rd field and it won't cause an error, but no code makes actual use of it yet).

It's a decent first step to closing #4 I think.