### PR TITLE
Migrate to Neovim v0.7

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@ and trees
 
 - Modular, maintainable pure Lua way to define keymaps
 - Written in a single file of ~100 lines
-- Supports mapping keys to Lua functions with `expr` support
 - Allows grouping keymaps the way you think about them concisely
 
 ## Installation
@@ -110,7 +109,7 @@ You can change the defaults used by `applyKeymaps`:
 local nest = require('nest')
 
 nest.defaults.options = {
-    noremap = false,
+    remap = true,
 }
 ```
 
@@ -122,7 +121,7 @@ Defaults start out as
     prefix = '',
     buffer = false,
     options = {
-        noremap = true,
+        remap = false,
         silent = true,
     },
 }
@@ -184,7 +183,7 @@ to all containing sub-`keymapConfig`s:
 Sets the Vim mode(s) for keymaps contained in the `keymapConfig`.
 
 Accepts a string with each char representing a mode. The modes follow the Vim
-prefixes (`n` for normal, `i` for insert...) **except the special character `_`**, which 
+prefixes (`n` for normal, `i` for insert...) **except the special character `_`**, which
 stands for the empty mode (`:map `). See `:help map-table` for a reference.
 
 #### `buffer`
@@ -204,8 +203,8 @@ the `keymapConfig`.
 that you only have to pass the `options` you want to change instead of replacing
 the whole object.
 
-Accepts all values `nvim_set_keymap`s `options` parameter accepts. See `:help
-nvim_set_keymap`.
+Accepts all values `vim.keymap.set`s `options` parameter accepts. See `:help
+vim.keymap.set`.
 
 ### `nest.defaults`
 

--- a/README.md
+++ b/README.md
@@ -121,7 +121,6 @@ Defaults start out as
     prefix = '',
     buffer = false,
     options = {
-        remap = false,
         silent = true,
     },
 }

--- a/lua/nest.lua
+++ b/lua/nest.lua
@@ -34,47 +34,15 @@ local function functionToRhs(func, expr)
         or '<cmd>lua package.loaded.nest._callRhsFn(' .. insertedIndex .. ')<cr>'
 end
 
-local function copy(table)
-    local ret = {}
-
-    for key, value in pairs(table) do
-        ret[key] = value
-    end
-
-    return ret
-end
-
-local function mergeTables(left, right)
-    local ret = copy(left)
-
-    for key, value in pairs(right) do
-        ret[key] = value
-    end
-
-    return ret
-end
-
 local function mergeOptions(left, right)
-    local ret = copy(left)
-
     if right == nil then
-        return ret
+        return left or {}
     end
 
-    if right.mode ~= nil then
-        ret.mode = right.mode
-    end
-
-    if right.buffer ~= nil then
-        ret.buffer = right.buffer
-    end
+    local ret = vim.tbl_deep_extend("force", left, right) or {}
 
     if right.prefix ~= nil then
-        ret.prefix = ret.prefix .. right.prefix
-    end
-
-    if right.options ~= nil then
-        ret.options = mergeTables(ret.options, right.options)
+        ret.prefix = left.prefix .. right.prefix
     end
 
     return ret

--- a/lua/nest.lua
+++ b/lua/nest.lua
@@ -7,7 +7,6 @@ module.defaults = {
     prefix = '',
     buffer = false,
     options = {
-        remap = false,
         silent = true,
     },
 }

--- a/lua/nest.lua
+++ b/lua/nest.lua
@@ -60,11 +60,7 @@ module.applyKeymaps = function (config, presets)
         table.insert(sanitizedMode, sMode)
     end
 
-    if mergedPresets.buffer then
-        mergedPresets.options.buffer = (mergedPresets.buffer == true)
-            and 0
-            or mergedPresets.buffer
-    end
+    mergedPresets.options.buffer = mergedPresets.buffer
 
     vim.keymap.set(
         sanitizedMode,


### PR DESCRIPTION
Use Vim's table functions and `vim.keymap.set` instead of `nvim_set_keymap`; the latter was introduced with Neovim v0.7.  IMO, `vim.keymap.set` is more flexible as it allows lua functions as RHS and disables remap by default, so that the refactored code is less complex.

One may extend this change to adapt the API of `vim.keymap.set`:
 1. Specify the mode as a single letter (or empty string) or as a list of single-letter strings.  This frees us from handling `mode="_"` specially.
 2. Move the `buffer` option to the `options` table.

These changes would -- of course -- not be backwards compatible, but would be consistent with `vim.keymap.set` and reduce code complexity.

What do you think?
